### PR TITLE
v0.0.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "marvin",
-    "version": "0.0.19",
+    "version": "0.0.20",
     "license": "MIT",
     "scripts": {
         "dev": "electron-webpack dev",

--- a/src/common/local/english.js
+++ b/src/common/local/english.js
@@ -32,6 +32,7 @@ const TRANSLATION_ENGLISH = {
     modules: 'Modules',
     active: 'Active',
     settings: 'Settings',
+    quit: 'Quit',
 
     quality_error: 'Value must be between 0.0 and 1.0',
     size_error: 'Value must be an integer greater than 0',

--- a/src/common/local/english.js
+++ b/src/common/local/english.js
@@ -33,6 +33,7 @@ const TRANSLATION_ENGLISH = {
     active: 'Active',
     settings: 'Settings',
     quit: 'Quit',
+    open: 'Open',
 
     quality_error: 'Value must be between 0.0 and 1.0',
     size_error: 'Value must be an integer greater than 0',

--- a/src/common/local/german.js
+++ b/src/common/local/german.js
@@ -32,6 +32,7 @@ const TRANSLATION_GERMAN = {
     modules: 'Module',
     active: 'Aktiv',
     settings: 'Einstellungen',
+    quit: 'Beenden',
 
     quality_error: 'Der Wert muss zwischen 0,0 und 1,0 liegen',
     size_error: 'Der Wert muss eine Ganzzahl größer als 0 sein',

--- a/src/common/local/german.js
+++ b/src/common/local/german.js
@@ -33,6 +33,7 @@ const TRANSLATION_GERMAN = {
     active: 'Aktiv',
     settings: 'Einstellungen',
     quit: 'Beenden',
+    open: 'Öffnen',
 
     quality_error: 'Der Wert muss zwischen 0,0 und 1,0 liegen',
     size_error: 'Der Wert muss eine Ganzzahl größer als 0 sein',

--- a/src/common/local/italian.js
+++ b/src/common/local/italian.js
@@ -33,6 +33,7 @@ const TRANSLATION_ITALIAN = {
     active: 'Attivo',
     settings: 'Impostazioni',
     quit: 'Chiudi',
+    open: 'Aprire',
 
     quality_error: 'Il valore deve essere compreso tra 0,0 e 1,0',
     size_error: 'Il valore deve essere un numero intero maggiore di 0',

--- a/src/common/local/italian.js
+++ b/src/common/local/italian.js
@@ -32,6 +32,7 @@ const TRANSLATION_ITALIAN = {
     modules: 'Moduli',
     active: 'Attivo',
     settings: 'Impostazioni',
+    quit: 'Chiudi',
 
     quality_error: 'Il valore deve essere compreso tra 0,0 e 1,0',
     size_error: 'Il valore deve essere un numero intero maggiore di 0',

--- a/src/main/executor.js
+++ b/src/main/executor.js
@@ -1,5 +1,6 @@
 
 import { config } from "./config";
+import MainModule from "./modules/main";
 import SettingsModule from "./modules/settings";
 import LinuxSystemModule from './modules/linux-system';
 import AsyncLock from "async-lock";
@@ -27,6 +28,7 @@ import EmailModule from "./modules/email";
 import { generateSearchRegex } from "./search";
 
 const MODULES = {
+    main: MainModule,
     settings: SettingsModule,
     linux_system: LinuxSystemModule,
     folders: FoldersModule,

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,48 +1,24 @@
 
-import { app, globalShortcut, Tray, Menu } from 'electron';
-import path from 'path';
+import { app } from 'electron';
 import { loadConfig, config } from './config';
 import { initModules, deinitModules } from './executor';
-import { createMainWindow, destroyMainWindow, toggleMain } from './modules/main';
-import { createSettingsWindow, destroySettingsWindow, openSettingsWindow } from './modules/settings';
-import { getTranslation } from '../common/local/locale';
 
 app.commandLine.appendSwitch("disable-gpu"); // Transparancy will not work without this
-
-let tray;
 
 async function startApp() {
     const got_single_instance_lock = app.requestSingleInstanceLock();
     if (got_single_instance_lock) {
         loadConfig();
-        tray = new Tray(path.join(__static, 'logo.png'));
-        const context_menu = Menu.buildFromTemplate([
-            { label: getTranslation(config, 'settings'), type: 'normal', click: openSettingsWindow },
-            { label: getTranslation(config, 'quit'), type: 'normal', click: closeApp },
-        ]);
-        tray.setToolTip('Marvin');
-        tray.setContextMenu(context_menu);
         await initModules();
-        createMainWindow();
-        createSettingsWindow();
-        const ret = globalShortcut.register(config.general.global_shortcut, toggleMain);
-        if (!ret) {
-            console.error('Failed to register a global shortcut');
-            closeApp();
-        }
     } else {
         console.error("Other instance is already running: quitting app.");
-        closeApp();
+        app.quit();
     }
 }
 
 async function closeApp() {
-    globalShortcut.unregisterAll();
-    destroyMainWindow();
-    destroySettingsWindow();
     await deinitModules();
-    app.quit();
 }
 
 app.on('ready', () => setTimeout(startApp, 500));
-app.on('before-exit', closeApp);
+app.on('before-quit', closeApp);

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,15 +1,25 @@
 
-import { app, globalShortcut } from 'electron';
+import { app, globalShortcut, Tray, Menu } from 'electron';
+import path from 'path';
 import { loadConfig, config } from './config';
 import { initModules, deinitModules } from './executor';
 import { createMainWindow, destroyMainWindow, toggleMain } from './main';
-import { createSettingsWindow, destroySettingsWindow } from './modules/settings';
+import { createSettingsWindow, destroySettingsWindow, openSettingsWindow } from './modules/settings';
 
 app.commandLine.appendSwitch("disable-gpu"); // Transparancy will not work without this
 
+let tray;
+
 async function startApp() {
-    const gotSingleInstanceLock = app.requestSingleInstanceLock();
-    if (gotSingleInstanceLock) {
+    const got_single_instance_lock = app.requestSingleInstanceLock();
+    if (got_single_instance_lock) {
+        tray = new Tray(path.join(__static, 'logo.png'));
+        const context_menu = Menu.buildFromTemplate([
+            { label: 'Settings', type: 'normal', click: openSettingsWindow },
+            { label: 'Quit', type: 'normal', click: closeApp },
+        ]);
+        tray.setToolTip('Marvin');
+        tray.setContextMenu(context_menu);
         loadConfig();
         await initModules();
         createSettingsWindow();

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -3,8 +3,9 @@ import { app, globalShortcut, Tray, Menu } from 'electron';
 import path from 'path';
 import { loadConfig, config } from './config';
 import { initModules, deinitModules } from './executor';
-import { createMainWindow, destroyMainWindow, toggleMain } from './main';
+import { createMainWindow, destroyMainWindow, toggleMain } from './modules/main';
 import { createSettingsWindow, destroySettingsWindow, openSettingsWindow } from './modules/settings';
+import { getTranslation } from '../common/local/locale';
 
 app.commandLine.appendSwitch("disable-gpu"); // Transparancy will not work without this
 
@@ -13,17 +14,17 @@ let tray;
 async function startApp() {
     const got_single_instance_lock = app.requestSingleInstanceLock();
     if (got_single_instance_lock) {
+        loadConfig();
         tray = new Tray(path.join(__static, 'logo.png'));
         const context_menu = Menu.buildFromTemplate([
-            { label: 'Settings', type: 'normal', click: openSettingsWindow },
-            { label: 'Quit', type: 'normal', click: closeApp },
+            { label: getTranslation(config, 'settings'), type: 'normal', click: openSettingsWindow },
+            { label: getTranslation(config, 'quit'), type: 'normal', click: closeApp },
         ]);
         tray.setToolTip('Marvin');
         tray.setContextMenu(context_menu);
-        loadConfig();
         await initModules();
-        createSettingsWindow();
         createMainWindow();
+        createSettingsWindow();
         const ret = globalShortcut.register(config.general.global_shortcut, toggleMain);
         if (!ret) {
             console.error('Failed to register a global shortcut');

--- a/src/main/modules/linux-applications.js
+++ b/src/main/modules/linux-applications.js
@@ -280,7 +280,7 @@ const LinuxApplicationModule = {
                 executable: true,
                 quality: Math.max(
                     app_match,
-                    ...(getProps(value, 'Name').map((prop) => 0.75 * stringMatchQuality(query, prop, regex))),
+                    ...(getProps(value, 'Name').map((prop) => 0.5 * stringMatchQuality(query, prop, regex))),
                     ...(getProps(value, 'Comment').map((prop) => 0.25 * stringMatchQuality(query, prop, regex)))
                 ),
                 app: value,

--- a/src/main/modules/main.js
+++ b/src/main/modules/main.js
@@ -4,7 +4,8 @@ import * as path from 'path';
 import { format as formatUrl } from 'url';
 import { config } from '../config';
 import { executeOption, searchQuery } from '../executor';
-import { getTranslation } from '../../common/local/locale';
+import { getTranslation, getAllTranslation } from '../../common/local/locale';
+import { stringMatchQuality } from '../search';
 import { openSettingsWindow } from './settings';
 
 const isDevelopment = process.env.NODE_ENV !== 'production';

--- a/src/main/modules/main.js
+++ b/src/main/modules/main.js
@@ -135,6 +135,12 @@ const MainModule = {
         tray = new Tray(path.join(__static, 'logo.png'));
         tray.setToolTip('Marvin');
         const context_menu = Menu.buildFromTemplate([
+            {
+                label: getTranslation(config, 'open'),
+                type: 'normal',
+                click: () => toggleMain(true),
+                accelerator: config.general.global_shortcut
+            },
             { label: getTranslation(config, 'settings'), type: 'normal', click: openSettingsWindow },
             { label: getTranslation(config, 'quit'), type: 'normal', click: app.quit.bind(app) },
         ]);
@@ -147,6 +153,12 @@ const MainModule = {
     },
     update: async () => {
         const context_menu = Menu.buildFromTemplate([
+            {
+                label: getTranslation(config, 'open'),
+                type: 'normal',
+                click: () => toggleMain(true),
+                accelerator: config.general.global_shortcut
+            },
             { label: getTranslation(config, 'settings'), type: 'normal', click: openSettingsWindow },
             { label: getTranslation(config, 'quit'), type: 'normal', click: app.quit.bind(app) },
         ]);

--- a/src/main/modules/main.js
+++ b/src/main/modules/main.js
@@ -148,7 +148,6 @@ const MainModule = {
         const ret = globalShortcut.register(config.general.global_shortcut, toggleMain);
         if (!ret) {
             console.error('Failed to register a global shortcut');
-            app.quit();
         }
     },
     update: async () => {

--- a/src/main/modules/scripts.js
+++ b/src/main/modules/scripts.js
@@ -1,6 +1,5 @@
 
 import { config } from '../config';
-import { getTranslation } from '../../common/local/locale';
 import { exec } from "child_process";
 import { stringMatchQuality } from '../search';
 

--- a/src/main/modules/settings.js
+++ b/src/main/modules/settings.js
@@ -79,6 +79,12 @@ export function destroySettingsWindow() {
     }
 }
 
+export function openSettingsWindow() {
+    settings_window.webContents.send('update-config', config);
+    settings_window.show();
+    settings_window.focus();
+}
+
 const SettingsModule = {
     valid: (query) => {
         return query.trim().length >= 1;
@@ -96,10 +102,8 @@ const SettingsModule = {
             quality: settings_match,
         }];
     },
-    execute: async (option) => {
-        settings_window.webContents.send('update-config', config);
-        settings_window.show();
-        settings_window.focus();
+    execute: async (_) => {
+        openSettingsWindow();
     },
 }
 

--- a/src/main/modules/settings.js
+++ b/src/main/modules/settings.js
@@ -86,6 +86,12 @@ export function openSettingsWindow() {
 }
 
 const SettingsModule = {
+    init: async () => {
+        createSettingsWindow();
+    },
+    deinit: async () => {
+        destroySettingsWindow();
+    },
     valid: (query) => {
         return query.trim().length >= 1;
     },


### PR DESCRIPTION
* Added an option to quit the application
* Added a tray icon
  * Allows opening the main window without the shortcut
  * Allows opening the settings window directly
  * Allows quitting the application
* Improved search ordering for the Linux applications module
* No longer quitting when the global shortcut cannot be registered (You can still access the tray icon)
 
Internal (No difference to the user):
* Added the main module which now handles the main window, tray icon and global shortcut
* Moved everything concerning the settings window (creation/destruction) into the settings module